### PR TITLE
feat(sponsors): update sponsorship packs

### DIFF
--- a/src/app/devenir-sponsor/page.tsx
+++ b/src/app/devenir-sponsor/page.tsx
@@ -1,216 +1,33 @@
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Trophy, Medal, Award, Sparkles, CheckCircle2, Megaphone, Users, Mic2 } from "lucide-react";
-
-const RATE_XOF_PER_USD = 600;
-
-const tiers = [
-	{ key: "gold", xof: 600_000 },
-	{ key: "silver", xof: 300_000 },
-	{ key: "bronze", xof: 100_000 },
-	{ key: "custom", xof: null as number | null },
-] as const;
-
-function formatMoney(amount: number, currency: string) {
-	try {
-		return new Intl.NumberFormat(undefined, { style: "currency", currency }).format(amount);
-	} catch {
-		// Fallback for XOF (some environments may not support XOF currency style reliably)
-		return `${amount.toLocaleString()} ${currency}`;
-	}
-}
+import SponsorCarousel from "@/components/sections/sponsor-carousel";
 
 export const metadata = {
-	title: "Devenez sponsor – LOSL-CON 2025",
-	description: "Soutenez la conférence et bénéficiez d’une visibilité privilégiée",
+  title: "Devenez sponsor – LOSL-CON 2025",
+  description:
+    "Soutenez la conférence et bénéficiez d’une visibilité privilégiée",
 };
 
 export default function SponsorPage() {
-	return (
-		<main className="container mx-auto max-w-6xl px-4 py-16 sm:py-20 overflow-hidden">
-			<header className="relative mx-auto max-w-3xl text-center">
-				{/* Soft glow background */}
-				<span aria-hidden className="pointer-events-none absolute inset-0 -z-10">
-					<span className="absolute left-1/2 top-1/2 h-[480px] w-[480px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[radial-gradient(circle_at_center,theme(colors.accent/18),transparent_60%)] blur-3xl" />
-				</span>
-				<h1 className="text-3xl sm:text-5xl font-extrabold tracking-tight">
-					<span data-i18n="sponsor.title">Devenez sponsor – LOSL-CON 2025</span>
-				</h1>
-				<p className="mt-4 text-base sm:text-lg text-muted-foreground" data-i18n="sponsor.subtitle">
-					Accédez à une audience engagée. Gagnez en visibilité. Recrutez vos futurs talents.
-				</p>
-			</header>
-
-			{/* Tier cards */}
-			<section className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-4 md:gap-4">
-				{tiers.map((t) => {
-					const usd = t.xof ? Math.round(t.xof / RATE_XOF_PER_USD) : null;
-					const isGold = t.key === "gold";
-					const isSilver = t.key === "silver";
-					const isBronze = t.key === "bronze";
-					const colors = isGold
-						? {
-								ring: "ring-amber-400/40",
-								badge: "bg-gradient-to-r from-amber-300 to-amber-500 text-black",
-								icon: "text-amber-300",
-								halo:
-									"bg-[radial-gradient(80%_80%_at_50%_0%,rgba(245,158,11,0.25),transparent_70%)]",
-						  }
-						: isSilver
-						? {
-								ring: "ring-slate-300/40",
-								badge: "bg-gradient-to-r from-slate-200 to-slate-400 text-black",
-								icon: "text-slate-200",
-								halo:
-									"bg-[radial-gradient(80%_80%_at_50%_0%,rgba(203,213,225,0.22),transparent_70%)]",
-						  }
-						: isBronze
-						? {
-								ring: "ring-orange-400/40",
-								badge: "bg-gradient-to-r from-orange-300 to-orange-600 text-black",
-								icon: "text-orange-300",
-								halo:
-									"bg-[radial-gradient(80%_80%_at_50%_0%,rgba(234,88,12,0.22),transparent_70%)]",
-						  }
-						: {
-								ring: "ring-primary/30",
-								badge: "bg-gradient-to-r from-primary/80 to-primary/60",
-								icon: "text-primary",
-								halo:
-									"bg-[radial-gradient(80%_80%_at_50%_0%,rgba(59,130,246,0.18),transparent_70%)]",
-						  };
-
-					const Icon = isGold ? Trophy : isSilver ? Medal : isBronze ? Award : Sparkles;
-
-					const benefits: string[] = isGold
-						? [
-								"Logo XXL sur scène & site",
-								"Message d’ouverture (3–5 min)",
-								"Espace stand premium",
-								"10 Pass VIP",
-								"Campagnes sur nos réseaux",
-						  ]
-						: isSilver
-						? [
-								"Grand logo sur scène & site",
-								"Participation à un panel",
-								"Espace stand dédié",
-								"6 Pass",
-								"Mention newsletter",
-						  ]
-						: isBronze
-						? [
-								"Logo sur site & écrans",
-								"3 Pass",
-								"Merci sur réseaux sociaux",
-								"Ajout goodies dans le swag",
-								"Listing sur la page sponsors",
-						  ]
-						: [
-								"Pack sur-mesure",
-								"Budget flexible",
-								"Idéal startups & communautés",
-								"Objectifs co-construits",
-								"Activation adaptée",
-						  ];
-
-					const mailto = `mailto:community@loslc.tech?subject=${encodeURIComponent(
-						`Sponsoring ${t.key.toUpperCase()} – LOSL-CON 2025`
-					)}`;
-
-					return (
-						<Card
-							key={t.key}
-							className={`relative flex h-full flex-col overflow-hidden bg-card/60 backdrop-blur ring-1 ${colors.ring}`}
-						>
-							{/* Decorative halo */}
-							<span aria-hidden className="pointer-events-none absolute inset-0 -z-10">
-								<span className={`absolute inset-0 ${colors.halo}`} />
-							</span>
-
-							<CardHeader className="space-y-3">
-								<div className="flex items-center justify-between">
-									<div className="flex items-center gap-3">
-										<span className={`rounded-lg bg-white/5 p-2 ${colors.icon}`}>
-											<Icon className="h-5 w-5" />
-										</span>
-										<CardTitle className="text-2xl capitalize">
-											<span data-i18n={`sponsor.tiers.${t.key}.name`}>{t.key}</span>
-										</CardTitle>
-									</div>
-									{isGold && (
-										<span className={`rounded-full px-2.5 py-1 text-xs font-medium ${colors.badge}`}>
-											<span data-i18n="sponsor.badges.top">Top visibilité</span>
-										</span>
-									)}
-									{isSilver && (
-										<span className={`rounded-full px-2.5 py-1 text-xs font-medium ${colors.badge}`}>
-											<span data-i18n="sponsor.badges.popular">Populaire</span>
-										</span>
-									)}
-								</div>
-								<CardDescription>
-									{t.xof !== null ? (
-										<span>
-											{formatMoney(t.xof, "XOF")} <span aria-hidden>•</span> ≈ ${usd?.toLocaleString()} USD
-										</span>
-									) : (
-										<span data-i18n="sponsor.tiers.custom.note">Contact personnalisé</span>
-									)}
-								</CardDescription>
-							</CardHeader>
-							<CardContent className="flex grow flex-col">
-								<ul className="space-y-2 text-sm text-foreground/90">
-									{benefits.map((b, i) => {
-										const key = `sponsor.tiers.${t.key}.benefit${i + 1}` as const;
-										return (
-											<li key={i} className="flex items-start gap-2">
-												<CheckCircle2 className={`mt-0.5 h-4 w-4 flex-none ${colors.icon}`} />
-												<span data-i18n={key}>{b}</span>
-											</li>
-										);
-									})}
-								</ul>
-								<div className="mt-4 flex flex-wrap gap-2 text-xs text-muted-foreground">
-									{isGold && (
-										<>
-											<span className="inline-flex items-center gap-1">
-												<Megaphone className="h-3.5 w-3.5" />{" "}
-												<span data-i18n="sponsor.features.mediaBoost">Media boost</span>
-											</span>
-											<span className="inline-flex items-center gap-1">
-												<Users className="h-3.5 w-3.5" />{" "}
-												<span data-i18n="sponsor.features.talentReach">Talent reach</span>
-											</span>
-											<span className="inline-flex items-center gap-1">
-												<Mic2 className="h-3.5 w-3.5" />{" "}
-												<span data-i18n="sponsor.features.sceneTime">Scene time</span>
-											</span>
-										</>
-									)}
-								</div>
-								<div className="mt-auto pt-4">
-									<Button asChild className="w-full">
-										<a href={mailto} data-i18n={`sponsor.cta.${t.key}`}>
-											Je deviens sponsor
-										</a>
-									</Button>
-								</div>
-							</CardContent>
-						</Card>
-					);
-				})}
-			</section>
-			<section className="mt-14 rounded-2xl border border-white/10 bg-white/5 p-6 sm:p-8 backdrop-blur-md">
-				<h2 className="text-xl sm:text-2xl font-semibold" data-i18n="sponsor.contact.heading">
-					Pour toute demande ou proposition de sponsoring, contactez-nous à :
-				</h2>
-				<p className="mt-3 text-muted-foreground">
-					<a href="mailto:community@loslc.tech" className="font-medium text-primary hover:underline">
-						community@loslc.tech
-					</a>
-				</p>
-			</section>
-		</main>
-	);
+  return (
+    <main className="overflow-hidden">
+      <SponsorCarousel />
+      <div className="container mx-auto max-w-6xl px-4 pb-16 sm:pb-20">
+        <section className="mt-14 rounded-2xl border border-white/10 bg-white/5 p-6 sm:p-8 backdrop-blur-md">
+          <h2
+            className="text-xl sm:text-2xl font-semibold"
+            data-i18n="sponsor.contact.heading"
+          >
+            Pour toute demande ou proposition de sponsoring, contactez-nous à :
+          </h2>
+          <p className="mt-3 text-muted-foreground">
+            <a
+              href="mailto:community@loslc.tech"
+              className="font-medium text-primary hover:underline"
+            >
+              community@loslc.tech
+            </a>
+          </p>
+        </section>
+      </div>
+    </main>
+  );
 }

--- a/src/components/sections/sponsor-carousel.tsx
+++ b/src/components/sections/sponsor-carousel.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  Crown,
+  Trophy,
+  Medal,
+  Award,
+  Sparkles,
+  CheckCircle2,
+  Megaphone,
+  Users,
+  Mic2,
+  ChevronUp,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
+
+const RATE_XOF_PER_USD = 600;
+
+type TierKey = "diamond" | "gold" | "silver" | "bronze" | "custom";
+
+const tiers: Array<{ key: TierKey; xof: number | null }> = [
+  { key: "diamond", xof: 6_000_000 },
+  { key: "gold", xof: 1_000_000 },
+  { key: "silver", xof: 600_000 },
+  { key: "bronze", xof: 200_000 },
+  { key: "custom", xof: null },
+];
+
+function formatMoney(amount: number, currency: string) {
+  try {
+    return new Intl.NumberFormat(undefined, { style: "currency", currency }).format(amount);
+  } catch {
+    return `${amount.toLocaleString()} ${currency}`;
+  }
+}
+
+export function SponsorCarousel() {
+  const slides = useMemo(() => {
+    return tiers.map((t) => {
+      const usd = t.xof ? Math.round(t.xof / RATE_XOF_PER_USD) : null;
+      const isDiamond = t.key === "diamond";
+      const isGold = t.key === "gold";
+      const isSilver = t.key === "silver";
+      const isBronze = t.key === "bronze";
+      const colors = isDiamond
+        ? {
+            ring: "ring-cyan-400/50",
+            badge: "bg-gradient-to-r from-cyan-200 to-cyan-400 text-black",
+            icon: "text-cyan-300",
+            halo: "bg-[radial-gradient(80%_80%_at_50%_0%,rgba(34,211,238,0.35),transparent_70%)]",
+            pageBg:
+              "radial-gradient(60% 60% at 50% 0%, rgba(34,211,238,0.20), rgba(0,0,0,0) 70%), linear-gradient(180deg, rgba(7, 89, 133, 0.25), rgba(2, 6, 23, 0.15))",
+          }
+        : isGold
+        ? {
+            ring: "ring-amber-400/40",
+            badge: "bg-gradient-to-r from-amber-300 to-amber-500 text-black",
+            icon: "text-amber-300",
+            halo: "bg-[radial-gradient(80%_80%_at_50%_0%,rgba(245,158,11,0.25),transparent_70%)]",
+            pageBg:
+              "radial-gradient(60% 60% at 50% 0%, rgba(245,158,11,0.18), rgba(0,0,0,0) 70%), linear-gradient(180deg, rgba(120, 53, 15, 0.20), rgba(23, 8, 2, 0.10))",
+          }
+        : isSilver
+        ? {
+            ring: "ring-slate-300/40",
+            badge: "bg-gradient-to-r from-slate-200 to-slate-400 text-black",
+            icon: "text-slate-200",
+            halo: "bg-[radial-gradient(80%_80%_at_50%_0%,rgba(203,213,225,0.22),transparent_70%)]",
+            pageBg:
+              "radial-gradient(60% 60% at 50% 0%, rgba(203,213,225,0.18), rgba(0,0,0,0) 70%), linear-gradient(180deg, rgba(15, 23, 42, 0.25), rgba(2, 6, 23, 0.10))",
+          }
+        : isBronze
+        ? {
+            ring: "ring-orange-400/40",
+            badge: "bg-gradient-to-r from-orange-300 to-orange-600 text-black",
+            icon: "text-orange-300",
+            halo: "bg-[radial-gradient(80%_80%_at_50%_0%,rgba(234,88,12,0.22),transparent_70%)]",
+            pageBg:
+              "radial-gradient(60% 60% at 50% 0%, rgba(234,88,12,0.18), rgba(0,0,0,0) 70%), linear-gradient(180deg, rgba(88, 28, 7, 0.18), rgba(23, 10, 2, 0.10))",
+          }
+        : {
+            ring: "ring-primary/30",
+            badge: "bg-gradient-to-r from-primary/80 to-primary/60",
+            icon: "text-primary",
+            halo: "bg-[radial-gradient(80%_80%_at_50%_0%,rgba(59,130,246,0.18),transparent_70%)]",
+            pageBg:
+              "radial-gradient(60% 60% at 50% 0%, rgba(59,130,246,0.18), rgba(0,0,0,0) 70%), linear-gradient(180deg, rgba(23, 37, 84, 0.22), rgba(2, 6, 23, 0.10))",
+          };
+
+      const Icon = isDiamond ? Crown : isGold ? Trophy : isSilver ? Medal : isBronze ? Award : Sparkles;
+
+      const benefits: string[] = isDiamond
+        ? [
+            "Logo géant sur scène & site",
+            "Keynote d'ouverture (10-15 min)",
+            "Espace stand exclusif premium",
+            "20 Pass VIP + accès backstage",
+            "Campagne marketing dédiée",
+            "Co-branding événement",
+            "Interview vidéo exclusive",
+          ]
+        : isGold
+        ? [
+            "Logo XXL sur scène & site",
+            "Message d'ouverture (5-8 min)",
+            "Espace stand premium",
+            "12 Pass VIP",
+            "Campagnes sur nos réseaux",
+            "Mention dans newsletter",
+            "Accès VIP networking",
+          ]
+        : isSilver
+        ? [
+            "Grand logo sur scène & site",
+            "Participation à un panel",
+            "Espace stand dédié",
+            "8 Pass",
+            "Mention newsletter",
+            "Post réseaux sociaux",
+            "Accès networking",
+          ]
+        : isBronze
+        ? [
+            "Logo sur site & écrans",
+            "4 Pass",
+            "Merci sur réseaux sociaux",
+            "Ajout goodies dans le swag",
+            "Listing sur la page sponsors",
+            "Accès cocktail networking",
+          ]
+        : [
+            "Pack sur-mesure",
+            "Budget flexible",
+            "Idéal startups & communautés",
+            "Objectifs co-construits",
+            "Activation adaptée",
+          ];
+
+      const mailto = `mailto:community@loslc.tech?subject=${encodeURIComponent(
+        `Sponsoring ${t.key.toUpperCase()} – LOSL-CON 2025`
+      )}`;
+
+      return { t, usd, colors, Icon, benefits, isDiamond, isGold } as const;
+    });
+  }, []);
+
+  const [index, setIndex] = useState(0);
+  const timerRef = useRef<number | null>(null);
+  const pausedRef = useRef(false);
+
+  useEffect(() => {
+    const play = () => {
+      timerRef.current = window.setInterval(() => {
+        if (!pausedRef.current) {
+          setIndex((i) => (i + 1) % slides.length);
+        }
+      }, 6000);
+    };
+    play();
+    return () => {
+      if (timerRef.current) window.clearInterval(timerRef.current);
+    };
+  }, [slides.length]);
+
+  const active = slides[index];
+
+  return (
+    <section
+      className="relative h-screen w-full overflow-hidden"
+      style={{ background: active.colors.pageBg }}
+    >
+      {/* Page header inside full-screen area */}
+      <div className="pointer-events-none absolute left-1/2 top-8 z-20 w-full max-w-4xl -translate-x-1/2 px-4 text-center">
+        <h1 className="text-3xl sm:text-5xl font-extrabold tracking-tight">
+          <span data-i18n="sponsor.title">Devenez sponsor – LOSL-CON 2025</span>
+        </h1>
+        <p className="mt-3 text-sm sm:text-lg text-muted-foreground" data-i18n="sponsor.subtitle">
+          Accédez à une audience engagée. Gagnez en visibilité. Recrutez vos futurs talents.
+        </p>
+      </div>
+      {/* Slides */}
+      <div
+        className="h-full w-full transition-transform duration-700 ease-in-out"
+        style={{ transform: `translateY(-${index * 100}%)` }}
+        onMouseEnter={() => (pausedRef.current = true)}
+        onMouseLeave={() => (pausedRef.current = false)}
+      >
+        {slides.map(({ t, usd, colors, Icon, benefits, isDiamond, isGold }, i) => (
+          <div key={t.key} className="h-screen w-full">
+            <div className="relative flex h-full items-center justify-center p-4 sm:p-8">
+              {/* Halo */}
+              <span aria-hidden className="pointer-events-none absolute inset-0 -z-10">
+                <span className={`absolute inset-0 ${colors.halo}`} />
+              </span>
+
+              <Card className={`mx-auto w-full max-w-md sm:max-w-lg md:max-w-xl lg:max-w-2xl bg-card/60 backdrop-blur ring-1 ${colors.ring}`}>
+                <CardHeader className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <span className={`rounded-lg bg-white/5 p-2 ${colors.icon}`}>
+                        <Icon className="h-5 w-5" />
+                      </span>
+                      <CardTitle className="text-3xl capitalize">
+                        <span data-i18n={`sponsor.tiers.${t.key}.name`}>{t.key}</span>
+                      </CardTitle>
+                    </div>
+                    {t.key === "diamond" && (
+                      <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${colors.badge}`}>
+                        <span data-i18n="sponsor.badges.premium">Premium Elite</span>
+                      </span>
+                    )}
+                    {t.key === "gold" && (
+                      <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${colors.badge}`}>
+                        <span data-i18n="sponsor.badges.top">Top visibilité</span>
+                      </span>
+                    )}
+                  </div>
+                  <CardDescription>
+                    {t.xof !== null ? (
+                      <span>
+                        {formatMoney(t.xof, "XOF")} <span aria-hidden>•</span> ≈ ${usd?.toLocaleString()} USD
+                      </span>
+                    ) : (
+                      <span data-i18n="sponsor.tiers.custom.note">Contact personnalisé</span>
+                    )}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="flex grow flex-col">
+                  <ul className="space-y-2 text-sm text-foreground/90">
+                    {benefits.map((b, idx) => (
+                      <li key={idx} className="flex items-start gap-2">
+                        <CheckCircle2 className={`mt-0.5 h-4 w-4 flex-none ${colors.icon}`} />
+                        <span data-i18n={`sponsor.tiers.${t.key}.benefit${idx + 1}`}>{b}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  <div className="mt-4 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                    {isDiamond && (
+                      <>
+                        <span className="inline-flex items-center gap-1">
+                          <Sparkles className="h-3.5 w-3.5" /> <span data-i18n="sponsor.features.exclusive">Exclusivité totale</span>
+                        </span>
+                        <span className="inline-flex items-center gap-1">
+                          <Megaphone className="h-3.5 w-3.5" /> <span data-i18n="sponsor.features.cobranding">Co-branding</span>
+                        </span>
+                        <span className="inline-flex items-center gap-1">
+                          <Mic2 className="h-3.5 w-3.5" /> <span data-i18n="sponsor.features.keynote">Keynote exclusive</span>
+                        </span>
+                        <span className="inline-flex items-center gap-1">
+                          <Users className="h-3.5 w-3.5" /> <span data-i18n="sponsor.features.backstage">Accès backstage</span>
+                        </span>
+                      </>
+                    )}
+                    {isGold && (
+                      <>
+                        <span className="inline-flex items-center gap-1">
+                          <Megaphone className="h-3.5 w-3.5" /> <span data-i18n="sponsor.features.mediaBoost">Media boost</span>
+                        </span>
+                        <span className="inline-flex items-center gap-1">
+                          <Users className="h-3.5 w-3.5" /> <span data-i18n="sponsor.features.talentReach">Talent reach</span>
+                        </span>
+                        <span className="inline-flex items-center gap-1">
+                          <Mic2 className="h-3.5 w-3.5" /> <span data-i18n="sponsor.features.sceneTime">Scene time</span>
+                        </span>
+                      </>
+                    )}
+                  </div>
+                  <div className="mt-auto pt-6">
+                    <Button asChild className="w-full">
+                      <a
+                        href={`mailto:community@loslc.tech?subject=${encodeURIComponent(
+                          `Sponsoring ${t.key.toUpperCase()} – LOSL-CON 2025`
+                        )}`}
+                        data-i18n={`sponsor.cta.${t.key}`}
+                      >
+                        Je deviens sponsor
+                      </a>
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Prev / Next controls (desktop/tablet) */}
+      <div className="pointer-events-auto absolute top-1/2 right-4 z-20 -translate-y-1/2 hidden sm:flex flex-col gap-2">
+        <button
+          aria-label="Previous"
+          className="rounded-full bg-background/70 p-2 backdrop-blur ring-1 ring-white/10 hover:bg-background/90 transition"
+          onClick={() => setIndex((i) => (i - 1 + slides.length) % slides.length)}
+        >
+          <ChevronUp className="h-5 w-5" />
+        </button>
+        <button
+          aria-label="Next"
+          className="rounded-full bg-background/70 p-2 backdrop-blur ring-1 ring-white/10 hover:bg-background/90 transition"
+          onClick={() => setIndex((i) => (i + 1) % slides.length)}
+        >
+          <ChevronDown className="h-5 w-5" />
+        </button>
+      </div>
+
+      {/* Dots (desktop/tablet) */}
+      <div className="pointer-events-auto absolute bottom-6 left-1/2 z-10 -translate-x-1/2 hidden sm:block">
+        <div className="flex items-center gap-2 rounded-full bg-background/60 px-3 py-2 backdrop-blur">
+          {slides.map((s, i) => (
+            <button
+              key={s.t.key}
+              aria-label={`Go to ${s.t.key}`}
+              className={`h-2.5 w-2.5 rounded-full transition-all ${i === index ? "bg-primary w-6" : "bg-foreground/30"}`}
+              onClick={() => setIndex(i)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Mobile controls: dots + horizontal prev/next under the carousel */}
+      <div className="pointer-events-auto absolute bottom-6 left-1/2 z-10 -translate-x-1/2 w-full max-w-sm px-4 sm:hidden">
+        <div className="flex flex-col items-center gap-3">
+          <div className="flex items-center gap-2 rounded-full bg-background/60 px-3 py-2 backdrop-blur">
+            {slides.map((s, i) => (
+              <button
+                key={s.t.key}
+                aria-label={`Go to ${s.t.key}`}
+                className={`h-2.5 w-2.5 rounded-full transition-all ${i === index ? "bg-primary w-6" : "bg-foreground/30"}`}
+                onClick={() => setIndex(i)}
+              />
+            ))}
+          </div>
+          <div className="flex items-center gap-4">
+            <button
+              aria-label="Previous"
+              className="inline-flex items-center gap-2 rounded-full bg-background/70 px-4 py-2 text-sm backdrop-blur ring-1 ring-white/10 hover:bg-background/90 transition"
+              onClick={() => setIndex((i) => (i - 1 + slides.length) % slides.length)}
+            >
+              <ChevronLeft className="h-4 w-4" />
+              <span>Prev</span>
+            </button>
+            <button
+              aria-label="Next"
+              className="inline-flex items-center gap-2 rounded-full bg-background/70 px-4 py-2 text-sm backdrop-blur ring-1 ring-white/10 hover:bg-background/90 transition"
+              onClick={() => setIndex((i) => (i + 1) % slides.length)}
+            >
+              <span>Next</span>
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default SponsorCarousel;

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -32,7 +32,7 @@
     "stats": {
   "speakers": "5",
       "speakers_label": "Expert speakers",
-  "attendees": "150+",
+  "attendees": "300+",
       "attendees_label": "Attendees",
   "workshops": "3",
       "workshops_label": "Hands-on workshops",
@@ -95,7 +95,7 @@
   "dateDesc": "Full-day event",
   "location": "Lomé, Togo",
   "venue": "Institut Français du Togo",
-  "capacity": "150+ Attendees",
+  "capacity": "300+ Attendees",
   "networking": "Premium networking",
   "benefits": "Goodies included",
   "swag": "Certificates & more",
@@ -138,34 +138,50 @@
     "title": "Become a sponsor – LOSL-CON 2025",
   "subtitle": "Reach an engaged audience. Boost your visibility. Hire your next talents.",
     "badges": {
+      "premium": "Premium Elite",
       "top": "Top visibility",
       "popular": "Popular"
     },
     "tiers": {
+      "diamond": {
+        "name": "Diamond",
+        "benefit1": "Giant logo on stage & website",
+  "benefit2": "Opening keynote (10-15 min)",
+        "benefit3": "Exclusive premium booth",
+        "benefit4": "20 VIP passes + backstage",
+        "benefit5": "Dedicated marketing campaign",
+        "benefit6": "Event co-branding",
+        "benefit7": "Exclusive video interview"
+      },
       "gold": {
         "name": "Gold",
         "benefit1": "XXL logo on stage & website",
-        "benefit2": "Opening message (3–5 min)",
+  "benefit2": "Opening message (3–5 min)",
         "benefit3": "Premium booth space",
-        "benefit4": "10 VIP passes",
-        "benefit5": "Campaigns on our socials"
-      },
+  "benefit4": "10 VIP passes",
+  "benefit5": "Campaigns on our socials",
+  "benefit6": "Newsletter mention",
+  "benefit7": "VIP networking access"
+  },
       "silver": {
         "name": "Silver",
         "benefit1": "Large logo on stage & website",
         "benefit2": "Join a panel discussion",
         "benefit3": "Dedicated booth space",
-        "benefit4": "6 passes",
-        "benefit5": "Newsletter mention"
-      },
+  "benefit4": "6 passes",
+  "benefit5": "Newsletter mention",
+  "benefit6": "Social media post",
+  "benefit7": "Networking access"
+  },
       "bronze": {
         "name": "Bronze",
         "benefit1": "Logo on website & screens",
-        "benefit2": "3 passes",
+  "benefit2": "3 passes",
         "benefit3": "Social media thanks",
         "benefit4": "Add goodies to swag",
-        "benefit5": "Listed on sponsors page"
-      },
+  "benefit5": "Listed on sponsors page",
+  "benefit6": "Networking cocktail access"
+  },
       "custom": {
         "name": "Other contribution",
         "note": "Custom contact",
@@ -174,18 +190,23 @@
         "benefit3": "Ideal for startups & communities",
         "benefit4": "Co-built objectives",
         "benefit5": "Fitted activations"
-      }
+  }
     },
     "features": {
+  "exclusive": "Total exclusivity",
+  "cobranding": "Co-branding",
+  "keynote": "Exclusive keynote",
+  "backstage": "Backstage access",
       "mediaBoost": "Media boost",
       "talentReach": "Talent reach",
       "sceneTime": "Stage time"
     },
     "cta": {
-      "gold": "Become a sponsor",
-      "silver": "Become a sponsor",
-      "bronze": "Become a sponsor",
-      "custom": "Become a sponsor"
+  "diamond": "Become a sponsor",
+  "gold": "Become a sponsor",
+  "silver": "Become a sponsor",
+  "bronze": "Become a sponsor",
+  "custom": "Become a sponsor"
     },
     "contact": {
       "heading": "For any sponsorship request or proposal, contact us at:"

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -32,7 +32,7 @@
     "stats": {
   "speakers": "5",
       "speakers_label": "Speakers experts",
-  "attendees": "150+",
+  "attendees": "300+",
       "attendees_label": "Participants",
   "workshops": "3",
       "workshops_label": "Ateliers pratiques",
@@ -95,7 +95,7 @@
   "dateDesc": "Journée complète",
   "location": "Lomé, Togo",
   "venue": "Institut Français du Togo",
-  "capacity": "150+ Participants",
+  "capacity": "300+ Participants",
   "networking": "Networking premium",
   "benefits": "Goodies inclus",
   "swag": "Certificats & plus",
@@ -138,33 +138,49 @@
     "title": "Devenez sponsor – LOSL-CON 2025",
   "subtitle": "Accédez à une audience engagée. Gagnez en visibilité. Recrutez vos futurs talents.",
     "badges": {
+      "premium": "Premium Elite",
       "top": "Top visibilité",
       "popular": "Populaire"
     },
     "tiers": {
+      "diamond": {
+        "name": "Diamond",
+        "benefit1": "Logo géant sur scène & site",
+        "benefit2": "Keynote d'ouverture (10-15 min)",
+        "benefit3": "Espace stand exclusif premium",
+        "benefit4": "20 Pass VIP + accès backstage",
+        "benefit5": "Campagne marketing dédiée",
+        "benefit6": "Co-branding événement",
+        "benefit7": "Interview vidéo exclusive"
+      },
       "gold": {
         "name": "Gold",
         "benefit1": "Logo XXL sur scène & site",
-        "benefit2": "Message d’ouverture (3–5 min)",
+  "benefit2": "Message d’ouverture (3–5 min)",
         "benefit3": "Espace stand premium",
-        "benefit4": "10 Pass VIP",
-        "benefit5": "Campagnes sur nos réseaux"
+  "benefit4": "10 Pass VIP",
+  "benefit5": "Campagnes sur nos réseaux",
+  "benefit6": "Mention dans newsletter",
+  "benefit7": "Accès VIP networking"
       },
       "silver": {
         "name": "Silver",
         "benefit1": "Grand logo sur scène & site",
         "benefit2": "Participation à un panel",
         "benefit3": "Espace stand dédié",
-        "benefit4": "6 Pass",
-        "benefit5": "Mention newsletter"
+  "benefit4": "6 Pass",
+  "benefit5": "Mention newsletter",
+  "benefit6": "Post réseaux sociaux",
+  "benefit7": "Accès networking"
       },
       "bronze": {
         "name": "Bronze",
         "benefit1": "Logo sur site & écrans",
-        "benefit2": "3 Pass",
+  "benefit2": "3 Pass",
         "benefit3": "Merci sur réseaux sociaux",
         "benefit4": "Ajout goodies dans le swag",
-        "benefit5": "Listing sur la page sponsors"
+  "benefit5": "Listing sur la page sponsors",
+  "benefit6": "Accès au cocktail networking"
       },
       "custom": {
         "name": "Autre contribution",
@@ -177,15 +193,20 @@
       }
     },
     "features": {
+  "exclusive": "Exclusivité totale",
+  "cobranding": "Co-branding",
+  "keynote": "Keynote exclusive",
+  "backstage": "Accès backstage",
       "mediaBoost": "Media boost",
       "talentReach": "Talent reach",
       "sceneTime": "Scene time"
     },
     "cta": {
-      "gold": "Je deviens sponsor",
-      "silver": "Je deviens sponsor",
-      "bronze": "Je deviens sponsor",
-      "custom": "Je deviens sponsor"
+  "diamond": "Je deviens sponsor",
+  "gold": "Je deviens sponsor",
+  "silver": "Je deviens sponsor",
+  "bronze": "Je deviens sponsor",
+  "custom": "Je deviens sponsor"
     },
     "contact": {
       "heading": "Pour toute demande ou proposition de sponsoring, contactez-nous à :"


### PR DESCRIPTION
This pull request refactors the sponsor page for LOSL-CON 2025 by introducing a new interactive carousel component for sponsor tiers, updating the sponsorship levels and benefits, and adjusting attendee capacity figures in the English locale. The changes modernize the sponsor presentation, add a new "Diamond" tier, and improve the user experience for both desktop and mobile visitors.

**Sponsor page redesign and tier updates:**

* Replaced the static sponsor tier grid in `page.tsx` with a new full-screen `SponsorCarousel` component, improving visual appeal and interactivity for sponsor options. [[1]](diffhunk://#diff-df7a7cf6bbf937888cafabec98463d457644d1b98ec519a7679c77d7f75df276L1-R30) [[2]](diffhunk://#diff-343f54e4a282e0daa5c6423ad0fab6d0462851b3bcbb53230e1b1dfbdd9953baR1-R361)
* Introduced a new "Diamond" sponsorship tier with enhanced benefits and a premium badge, and updated the amounts and benefits for all tiers.
* Updated the presentation logic to support carousel navigation, including auto-play, manual controls, and responsive design for mobile and desktop.

**Content and localization updates:**

* Increased the displayed attendee count and venue capacity from "150+" to "300+" in the English locale file, reflecting updated event expectations. [[1]](diffhunk://#diff-392337a519b62796951af1c3ed5fbf31e9a3c7b00af0841359150c2ed8ba786eL35-R35) [[2]](diffhunk://#diff-392337a519b62796951af1c3ed5fbf31e9a3c7b00af0841359150c2ed8ba786eL98-R98)