### PR TITLE
feat(attendees): Change the expected number of attendees range

### DIFF
--- a/src/components/sections/about.tsx
+++ b/src/components/sections/about.tsx
@@ -39,7 +39,7 @@ export function About() {
                 <div className="text-sm text-muted-foreground" data-i18n="about.stats.speakers_label">Speakers experts</div>
               </div>
               <div className="p-4 rounded-2xl bg-card/50 backdrop-blur border border-border/50">
-                <div className="text-2xl font-bold text-primary" data-i18n="about.stats.attendees">150+</div>
+                <div className="text-2xl font-bold text-primary" data-i18n="about.stats.attendees">300–500</div>
                 <div className="text-sm text-muted-foreground" data-i18n="about.stats.attendees_label">Participants</div>
               </div>
               <div className="p-4 rounded-2xl bg-card/50 backdrop-blur border border-border/50">

--- a/src/components/sections/join.tsx
+++ b/src/components/sections/join.tsx
@@ -98,7 +98,7 @@ export function Join() {
                           className="text-sm font-medium"
                           data-i18n="join.capacity"
                         >
-                          150+ Participants
+                          300–500 Participants
                         </div>
                         <div
                           className="text-xs text-muted-foreground"

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -32,7 +32,7 @@
     "stats": {
   "speakers": "5",
       "speakers_label": "Expert speakers",
-  "attendees": "300+",
+  "attendees": "300–500",
       "attendees_label": "Attendees",
   "workshops": "3",
       "workshops_label": "Hands-on workshops",
@@ -95,7 +95,7 @@
   "dateDesc": "Full-day event",
   "location": "Lomé, Togo",
   "venue": "Institut Français du Togo",
-  "capacity": "300+ Attendees",
+  "capacity": "300–500 Attendees",
   "networking": "Premium networking",
   "benefits": "Goodies included",
   "swag": "Certificates & more",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -32,7 +32,7 @@
     "stats": {
   "speakers": "5",
       "speakers_label": "Speakers experts",
-  "attendees": "300+",
+  "attendees": "300–500",
       "attendees_label": "Participants",
   "workshops": "3",
       "workshops_label": "Ateliers pratiques",
@@ -95,7 +95,7 @@
   "dateDesc": "Journée complète",
   "location": "Lomé, Togo",
   "venue": "Institut Français du Togo",
-  "capacity": "300+ Participants",
+  "capacity": "300–500 Participants",
   "networking": "Networking premium",
   "benefits": "Goodies inclus",
   "swag": "Certificats & plus",


### PR DESCRIPTION
This pull request updates the event attendee information across the site to reflect a new expected range of 300–500 participants, replacing the previous "150+" and "300+" values. The changes ensure consistency in both the UI components and the English and French localization files.

**Attendee count updates:**

* Updated the attendee number displayed in the `About` and `Join` sections to "300–500" instead of "150+" in `about.tsx` and `join.tsx`. [[1]](diffhunk://#diff-c4b63e7777b3bd6244dca9f2dd8920c99c6f9e1ec60b79d596c18bed607792d6L42-R42) [[2]](diffhunk://#diff-811f191077978079ed39a4d4e07224f42448daca38edec42ed13b956bde9e620L101-R101)

**Localization consistency:**

* Changed the attendee count and capacity strings in the English localization file `common.json` from "300+" to "300–500" for both stats and capacity. [[1]](diffhunk://#diff-392337a519b62796951af1c3ed5fbf31e9a3c7b00af0841359150c2ed8ba786eL35-R35) [[2]](diffhunk://#diff-392337a519b62796951af1c3ed5fbf31e9a3c7b00af0841359150c2ed8ba786eL98-R98)
* Changed the attendee count and capacity strings in the French localization file `common.json` from "300+" to "300–500" for both stats and capacity. [[1]](diffhunk://#diff-c674e48cbc6fe756bca2fa8e1c7fcae91342f8ac0809a31e9c345fc581fa6598L35-R35) [[2]](diffhunk://#diff-c674e48cbc6fe756bca2fa8e1c7fcae91342f8ac0809a31e9c345fc581fa6598L98-R98)